### PR TITLE
Add endpoint for comparing two envrionments

### DIFF
--- a/tests/api/test.yaml
+++ b/tests/api/test.yaml
@@ -151,6 +151,14 @@
     - compare: {jmespath: "bobbytables", expected: True}
 
 - test:
+  - name: 'compare to envs'
+  - url: '/api/envs/bob2/toggles?feature=bobbytables&feature=bobbytables2'
+  - headers: {'template': {'Cookie': '$cookie'}}
+  - validators:
+    - compare: {jmespath: "bobbytables2", expected: False}
+    - compare: {jmespath: "bobbytables", expected: True}
+
+- test:
   - name: 'turn toggle on bob2 off'
   - url: '/api/toggles'
   - headers: {'template': {'Cookie': '$cookie'}}

--- a/tmeister/core.py
+++ b/tmeister/core.py
@@ -87,6 +87,7 @@ def init():
     app.router.add_get('/api/envs', environments.get_envs)
     app.router.add_post('/api/envs', environments.add_env)
     app.router.add_delete('/api/envs/{name}', environments.delete_env)
+    app.router.add_get('/api/envs/{name}/diff', environments.compare_envs)
     app.router.add_get('/api/auditlog', auditing.get_audit_events)
     app.router.add_get('/heartbeat', health.get_health)
 

--- a/tmeister/dataaccess/toggleda.py
+++ b/tmeister/dataaccess/toggleda.py
@@ -1,5 +1,5 @@
 from asyncpgsa import pg
-
+from types import Dict
 from . import db
 
 
@@ -10,6 +10,16 @@ async def get_toggle_states_for_env(env, list_of_features):
 
     return {r.feature: r.state == 'ON'
             for r in await pg.fetch(query)}
+
+
+async def get_all_toggles_for_env(env) -> Dict[str, bool]:
+    query = db.toggles.select()\
+        .join(db.features,
+              onclause=db.features.c.name == db.toggles.c.feature,
+              isouter=True)\
+        .where(db.toggles.c.env == env)
+
+    return {r.feature: r.state == 'ON' for r in await pg.fetch(query)}
 
 
 async def set_toggle_state(env, feature, state):


### PR DESCRIPTION
Note: this PR is not intended to actually be merged. It is here for canopy interview purposes. Do *not* merge. If you are an interviewee, keep reading.

#### What this project does

This is a python micro service which allows canopy to use feature toggles in various environments, as-a-service. In other words, its a feature toggle service that manages states of features and environments and controls which features are live or not. 
This is a real project that canopy actually uses in production. 

#### What the pull request adds

The changes in this pull request add a new endpoint that compares two environments and tells you the difference between the feature states in the two environments.

#### Instructions for interviewee

Look over this pull request before coming into the interview. You do not need to actually submit comments or a review on Github. Instead, just look over the code and come prepared to discuss how things could be improved and the overall code quality.

You should be able to see everything you need in the Files Changed tab, but if you'd like to explore the entire codebase, feel free to do so.