### PR TITLE
Add migration to actually rename `Production` to production

### DIFF
--- a/migrations/versions/fa2cd0ecc30f_lower_case_production.py
+++ b/migrations/versions/fa2cd0ecc30f_lower_case_production.py
@@ -1,0 +1,40 @@
+"""lower case production
+
+Revision ID: fa2cd0ecc30f
+Revises: 1693a9b29733
+Create Date: 2019-04-23 10:01:13.744020
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = 'fa2cd0ecc30f'
+down_revision = '1693a9b29733'
+branch_labels = None
+depends_on = None
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+    bind = op.get_bind()
+    bind.execute("""
+        BEGIN;
+        ALTER TABLE toggles disable TRIGGER ALL;
+        UPDATE toggles SET env='production' where env='Production';
+        UPDATE environments set name='production' where name='Production';
+        ALTER TABLE toggles enable trigger all; 
+        COMMIT;
+    """)
+
+
+def downgrade():
+    bind = op.get_bind()
+    bind.execute("""
+            BEGIN;
+            ALTER TABLE toggles disable TRIGGER ALL;
+            UPDATE toggles SET env='Production' where env='production';
+            UPDATE environments set name='Production' where name='production';
+            ALTER TABLE toggles enable trigger all;
+            COMMIT; 
+        """)


### PR DESCRIPTION
Note: Phase 2 of a 3-step deploy to make envs case-insensitive