### PR TITLE
Image sizing support

### DIFF
--- a/tmeister/static/package-lock.json
+++ b/tmeister/static/package-lock.json
@@ -6522,6 +6522,11 @@
         "uc.micro": "^1.0.5"
       }
     },
+    "markdown-it-imsize": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/markdown-it-imsize/-/markdown-it-imsize-2.0.1.tgz",
+      "integrity": "sha1-zKBCeQXQUziiR8ucqdloxc3dUXA="
+    },
     "md5.js": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz",

--- a/tmeister/static/package.json
+++ b/tmeister/static/package.json
@@ -36,6 +36,7 @@
     "@material-ui/core": "^4.0.1",
     "fuzzy": "^0.1.3",
     "markdown-it": "^8.4.2",
+    "markdown-it-imsize": "^2.0.1",
     "moment": "^2.24.0",
     "prop-types": "^15.7.2",
     "react": "^16.8.6",

--- a/tmeister/static/src/release-notes/release-notes.helper.js
+++ b/tmeister/static/src/release-notes/release-notes.helper.js
@@ -1,2 +1,3 @@
 import markdownIt from 'markdown-it'
-export const md = new markdownIt()
+import markdownImageSize from 'markdown-it-imsize'
+export const md = new markdownIt().use(markdownImageSize)

--- a/tmeister/static/webpack.config.js
+++ b/tmeister/static/webpack.config.js
@@ -10,6 +10,9 @@ module.exports = {
     path: path.resolve(__dirname, 'build'),
   },
   mode: 'production',
+  node: {
+    fs: 'empty',
+  },
   module: {
     rules: [
       {


### PR DESCRIPTION
Supporting this syntax (github doesn't support it):

`![Star wars](https://screenrant.com/wp-content/uploads/2017/05/Star-Wars-Spinoffs-vs-Saga-Connection.jpg =100x)`

![Screenshot from 2019-06-25 13-42-51](https://user-images.githubusercontent.com/3059715/60128131-29bd6780-974f-11e9-81d9-512c6e2c38f4.png)

